### PR TITLE
Add udpxy multicast subscription renew

### DIFF
--- a/release/src/router/rc/wan.c
+++ b/release/src/router/rc/wan.c
@@ -427,6 +427,7 @@ start_igmpproxy(char *wan_ifname)
 			"-p", nvram_safe_get("udpxy_enable_x"),
 			"-B", "65536",
 			"-c", nvram_safe_get("udpxy_clients"),
+			"-M", "30",
 			"-a", nvram_get("lan_ifname") ? : "br0");
 	}
 


### PR DESCRIPTION
udpxy multicast subscription renew - Some IPTV providers request renew multicast subscription every XX sec. If not set IPTV stop working after subscription is expired.
info:(https://bitbucket.org/padavan/rt-n56u/issues/84/iptv-more-config-for-openwrt)